### PR TITLE
Secured Types Serialization Bug Fix

### DIFF
--- a/PixelAnticheat/SecuredTypes/SecuredByte.cs
+++ b/PixelAnticheat/SecuredTypes/SecuredByte.cs
@@ -35,10 +35,10 @@ namespace PixelAnticheat.SecuredTypes
         public static byte cryptoKeyEditor = cryptoKey;
 #endif
         
-        private byte currentCryptoKey;
-        private byte hiddenValue;
-        private byte fakeValue;
-        private bool inited;
+	    [SerializeField] private byte currentCryptoKey;
+	    [SerializeField] private byte hiddenValue;
+	    [SerializeField] private byte fakeValue;
+	    [SerializeField] private bool inited;
         
         /// <summary>
         /// Secured Byte Constructor

--- a/PixelAnticheat/SecuredTypes/SecuredChar.cs
+++ b/PixelAnticheat/SecuredTypes/SecuredChar.cs
@@ -35,10 +35,10 @@ namespace PixelAnticheat.SecuredTypes
         public static char cryptoKeyEditor = cryptoKey;
 #endif
         
-        private char currentCryptoKey;
-        private char hiddenValue;
-        private char fakeValue;
-        private bool inited;
+        [SerializeField] private char currentCryptoKey;
+        [SerializeField] private char hiddenValue;
+        [SerializeField] private char fakeValue;
+        [SerializeField] private bool inited;
 
         /// <summary>
         /// Secured Char Constructor

--- a/PixelAnticheat/SecuredTypes/SecuredDecimal.cs
+++ b/PixelAnticheat/SecuredTypes/SecuredDecimal.cs
@@ -36,10 +36,10 @@ namespace PixelAnticheat.SecuredTypes
         public static long cryptoKeyEditor = cryptoKey;
 #endif
         
-        private long currentCryptoKey;
-        private byte[] hiddenValue;
-        private decimal fakeValue;
-        private bool inited;
+	    [SerializeField] private long currentCryptoKey;
+	    [SerializeField] private byte[] hiddenValue;
+        [SerializeField] private decimal fakeValue;
+        [SerializeField] private bool inited;
         
         /// <summary>
         /// Secured Decimal Constructor

--- a/PixelAnticheat/SecuredTypes/SecuredDouble.cs
+++ b/PixelAnticheat/SecuredTypes/SecuredDouble.cs
@@ -36,10 +36,10 @@ namespace PixelAnticheat.SecuredTypes
         public static long cryptoKeyEditor = cryptoKey;
 #endif
         
-        private long currentCryptoKey;
-		private byte[] hiddenValue;
-		private double fakeValue;
-		private bool inited;
+	    [SerializeField] private long currentCryptoKey;
+	    [SerializeField] private byte[] hiddenValue;
+	    [SerializeField] private double fakeValue;
+	    [SerializeField] private bool inited;
 
 		/// <summary>
 		/// Secured Double Constructor

--- a/PixelAnticheat/SecuredTypes/SecuredLong.cs
+++ b/PixelAnticheat/SecuredTypes/SecuredLong.cs
@@ -35,10 +35,10 @@ namespace PixelAnticheat.SecuredTypes
         public static long cryptoKeyEditor = cryptoKey;
 #endif
         
-        private long currentCryptoKey;
-		private long hiddenValue;
-		private long fakeValue;
-		private bool inited;
+	    [SerializeField] private long currentCryptoKey;
+		[SerializeField] private long hiddenValue;
+		[SerializeField] private long fakeValue;
+		[SerializeField] private bool inited;
 
 		/// <summary>
 		/// Secured Long Constructor

--- a/PixelAnticheat/SecuredTypes/SecuredSByte.cs
+++ b/PixelAnticheat/SecuredTypes/SecuredSByte.cs
@@ -35,10 +35,10 @@ namespace PixelAnticheat.SecuredTypes
         public static sbyte cryptoKeyEditor = cryptoKey;
 #endif
 
-        private sbyte currentCryptoKey;
-		private sbyte hiddenValue;
-		private sbyte fakeValue;
-		private bool inited;
+        [SerializeField] private sbyte currentCryptoKey;
+        [SerializeField] private sbyte hiddenValue;
+        [SerializeField] private sbyte fakeValue;
+        [SerializeField] private bool inited;
 
 		/// <summary>
 		/// Secured SByte Constructor

--- a/PixelAnticheat/SecuredTypes/SecuredShort.cs
+++ b/PixelAnticheat/SecuredTypes/SecuredShort.cs
@@ -35,10 +35,10 @@ namespace PixelAnticheat.SecuredTypes
         public static short cryptoKeyEditor = cryptoKey;
 #endif
         
-        private short currentCryptoKey;
-		private short hiddenValue;
-		private short fakeValue;
-		private bool inited;
+	    [SerializeField] private short currentCryptoKey;
+	    [SerializeField] private short hiddenValue;
+	    [SerializeField] private short fakeValue;
+	    [SerializeField] private bool inited;
 
 		/// <summary>
 		/// Secured Short Constructor

--- a/PixelAnticheat/SecuredTypes/SecuredUInt.cs
+++ b/PixelAnticheat/SecuredTypes/SecuredUInt.cs
@@ -35,10 +35,10 @@ namespace PixelAnticheat.SecuredTypes
         public static uint cryptoKeyEditor = cryptoKey;
 #endif
 
-        private uint currentCryptoKey;
-		private uint hiddenValue;
-		private uint fakeValue;
-		private bool inited;
+	    [SerializeField] private uint currentCryptoKey;
+	    [SerializeField] private uint hiddenValue;
+	    [SerializeField] private uint fakeValue;
+	    [SerializeField] private bool inited;
 
 		/// <summary>
 		/// Secured UInt Constructor

--- a/PixelAnticheat/SecuredTypes/SecuredULong.cs
+++ b/PixelAnticheat/SecuredTypes/SecuredULong.cs
@@ -35,10 +35,10 @@ namespace PixelAnticheat.SecuredTypes
         public static ulong cryptoKeyEditor = cryptoKey;
 #endif
 
-        private ulong currentCryptoKey;
-		private ulong hiddenValue;
-		private ulong fakeValue;
-		private bool inited;
+        [SerializeField] private ulong currentCryptoKey;
+        [SerializeField] private ulong hiddenValue;
+        [SerializeField] private ulong fakeValue;
+		[SerializeField] private bool inited;
 
 		/// <summary>
 		/// Secured UShort Constructor

--- a/PixelAnticheat/SecuredTypes/SecuredUShort.cs
+++ b/PixelAnticheat/SecuredTypes/SecuredUShort.cs
@@ -35,10 +35,10 @@ namespace PixelAnticheat.SecuredTypes
         public static ushort cryptoKeyEditor = cryptoKey;
 #endif
 
-        private ushort currentCryptoKey;
-		private ushort hiddenValue;
-		private ushort fakeValue;
-		private bool inited;
+	    [SerializeField] private ushort currentCryptoKey;
+	    [SerializeField] private ushort hiddenValue;
+	    [SerializeField] private ushort fakeValue;
+	    [SerializeField] private bool inited;
 
 		/// <summary>
 		/// Secured UShort Constructor


### PR DESCRIPTION
Fixed Serialization / Deserialization for some secured types:
- SecuredByte;
- SecuredChar;
- SecuredDecimal;
- SecuredDouble;
- SecuredLong;
- SecuredSByte;
- SecuredShort;
- SecuredUInt;
- SecuredULong;
- SecuredUShort;

Updated Package;